### PR TITLE
Update module name to github.com/beauknowstech/gup for `go install` compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ gup (go-up) is meant to be a go replacement for `python3 -m http.server` with fe
 ![gup](images/gup.png?raw=true "output")
 
 ## Install
-Either compile yourself with `go build main.go` or download the gup binary from the releases page and put it somewhere in your `echo $PATH`. Mine is in /usr/bin/
+
+* Run `go install github.com/beauknowstech/gup@latest` (ensuring `$GOPATH` is in your `$PATH`)
+* Or download the gup binary from the releases page and put it somewhere in your `echo $PATH`. Mine is in /usr/bin/
+* Or compile yourself with `go build main.go` after cloning the repo
 
 ## Flags
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gup
+module github.com/beauknowstech/gup
 
 go 1.19
 

--- a/main.go
+++ b/main.go
@@ -3,14 +3,14 @@ package main
 import (
 	"flag"
 	"fmt"
-	"gup/internal/filelist"
-	"gup/internal/iplist"
-	"gup/internal/logger"
 	"log"
 	"net/http"
 	"os"
 	"strconv"
 
+	"github.com/beauknowstech/gup/internal/filelist"
+	"github.com/beauknowstech/gup/internal/iplist"
+	"github.com/beauknowstech/gup/internal/logger"
 	"github.com/fatih/color"
 )
 


### PR DESCRIPTION
This should work if this gets merged:

`go install github.com/beauknowstech/gup@latest` 

(Currently you'll get this error):
```sh
$ go install github.com/beauknowstech/gup@latest
go install: github.com/beauknowstech/gup@latest: github.com/beauknowstech/gup@v0.0.0-20230131031149-b2dd277f1b6b: parsing go.mod:
	module declares its path as: gup
	        but was required as: github.com/beauknowstech/gup
```

See https://go.dev/ref/mod#:~:text=a%20module%20path%20consists%20of%20a%20repository%20root%20path%2C%20a%20directory%20within%20the%20repository